### PR TITLE
Feature/frozen string

### DIFF
--- a/bin/semver
+++ b/bin/semver
@@ -52,7 +52,7 @@ begin
   when 'format'
     version = SemVer.find
     format_str = ARGV.shift or raise CommandError, "required: format string"
-    version.format format_str
+    puts version.format format_str
 
   when 'tag'
     version = SemVer.find

--- a/bin/semver
+++ b/bin/semver
@@ -52,7 +52,7 @@ begin
   when 'format'
     version = SemVer.find
     format_str = ARGV.shift or raise CommandError, "required: format string"
-    puts version.format format_str
+    puts version.format format_str.dup
 
   when 'tag'
     version = SemVer.find


### PR DESCRIPTION
I got a `'gsub!': can't modify frozen String (RuntimeError)`. 

This fixes the issue for both older and newer Ruby.
It also actually prints the formatted string, otherwise the function is kinda useless :smiley: 